### PR TITLE
[fix] use system line separator

### DIFF
--- a/src/test/java/com/bytelegend/ChallengeTest.java
+++ b/src/test/java/com/bytelegend/ChallengeTest.java
@@ -16,7 +16,7 @@ public class ChallengeTest {
         Dog dog2 = new Dog("Dog" + new Random().nextInt());
         capture.expect(
                 Matchers.containsString(
-                        dog1.getName() + " is walking\n" + dog2.getName() + " is walking\n"));
+                        dog1.getName() + " is walking" + System.lineSeparator() + dog2.getName() + " is walking" + System.lineSeparator()));
 
         Challenge.allDogsWalk(dog1, fish, dog2);
     }


### PR DESCRIPTION
修复 windows 系统下本地测试无法通过 bug。

将 \n 使用 System.lineSeparator() 替换